### PR TITLE
Add NYC AI for Code Roundtable event and Agentic Data Environments news

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -13,6 +13,22 @@
 # 
 #
 
+- title: 'Trustworthy AI for Code, Industry Roundtable NYC'
+  tag: Workshop
+  date: '2026-06-03'
+  who: Baishakhi Ray, Eugene Wu, Abhik Roychoudhury, Maja Vukovic
+  where: IBM Flagship Office, New York City
+  time: 9AM–5PM
+  link: https://spartan-nus.github.io/ai4code-roundtable-nyc.html
+  description: |
+    A curated gathering of leaders from industry and academia for a day of invited talks,
+    sharp discussion, and agenda-setting conversations on trustworthy AI for code. Co-hosted
+    by Columbia University's DAP Lab, NUS, and IBM Research.
+
+    The goal is to develop a shared understanding of trustworthy AI for code — including open
+    technical challenges, evaluation criteria, and concrete opportunities for collaboration.
+    Speakers include researchers from Google, Harvard, Princeton, and UC Berkeley.
+
 - title: '2026 North East AI Agents Day'
   tag: Workshop
   date: '2026-05-08'

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -15,6 +15,25 @@
 #
 
 - title: >
+    New Blog Series: [Agentic Data Environments](/general/2026/05/21/the-need-for-agentic-data-environments.html)
+  content: >
+    We're publishing a series of posts on what it takes to build data environments for AI agents.
+    The first post lays out the vision; the second digs into [why today's branchable databases
+    aren't ready for agentic workloads](/general/2026/05/26/branchable-databases-arent-ready-for-agentic-workloads.html).
+    More posts coming soon.
+  featured: true
+  date: 2026-05-26
+
+- title: >
+    [Trustworthy AI for Code, Industry Roundtable NYC](https://spartan-nus.github.io/ai4code-roundtable-nyc.html)
+  content: >
+    A curated, invite-only gathering of industry and academic leaders at the IBM Flagship Office
+    in New York City (June 3, 2026) to discuss trustworthy AI for code. Co-organized by DAPLab
+    (Eugene Wu), Baishakhi Ray (Columbia), Abhik Roychoudhury (NUS), and IBM Research.
+  featured: true
+  date: 2026-06-03
+
+- title: >
     [2026 North East AI Agents Day](https://ne-agents-day.github.io/)
   content: >
     A one-day workshop in New York City (May 8, 2026) bringing together ML,


### PR DESCRIPTION
## Summary

- **New event:** Trustworthy AI for Code, Industry Roundtable NYC (June 3, 2026) added to `_data/events.yml` — will appear as an upcoming event on the Events page and in the homepage Events card
- **News & Education (homepage):** Two new featured items in `_data/news.yml`:
  - NYC Roundtable — invite-only gathering at IBM Flagship Office, co-organized by DAP Lab (Eugene Wu), Baishakhi Ray, Abhik Roychoudhury (NUS), and Maja Vukovic (IBM)
  - Agentic Data Environments blog series — promotes the two published posts and teases more to come

## Test plan

- [ ] Verify NYC Roundtable appears under "Upcoming Events" on `/events`
- [ ] Verify both new items appear in the "News & Education" card on the homepage
- [ ] Check links to the roundtable site and blog posts resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)